### PR TITLE
Api change/use openstreetmap instead 

### DIFF
--- a/src/app/api/geocode/route.ts
+++ b/src/app/api/geocode/route.ts
@@ -1,0 +1,49 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+interface OpenCageResponse {
+  results: Array<unknown>;
+  status: {
+    code: number;
+    message: string;
+  };
+}
+
+export async function GET(request: Request): Promise<Response> {
+  const { searchParams } = new URL(request.url);
+  const address = searchParams.get("address");
+
+  if (!address) {
+    return new Response(JSON.stringify({ error: "Address is required" }), {
+      status: 400,
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+  }
+
+  try {
+    const response = await fetch(
+      `https://api.opencagedata.com/geocode/v1/json?key=${
+        process.env.OPENCAGE_API_KEY as string
+      }&q=${encodeURIComponent(address)}&limit=1&countrycode=CA&language=en`
+    );
+
+    if (!response.ok) {
+      throw new Error(`Error fetching data: ${response.statusText}`);
+    }
+
+    const data: OpenCageResponse = await response.json();
+    return new Response(JSON.stringify(data), {
+      status: 200,
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+  } catch (error: any) {
+    return new Response(JSON.stringify({ error: error.message }), {
+      status: 500,
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+  }
+}

--- a/src/components/ClientOnlyMap.tsx
+++ b/src/components/ClientOnlyMap.tsx
@@ -11,7 +11,6 @@ type Props = {
 }
 
 // This tries to access the document, so we need to make it into an ssr:false
-
 const ClientOnlyMap = ({ lat, lng }: Props) => {
     const icon = L.icon({
         iconUrl: '/images/pin.svg',

--- a/src/components/PropertyMap.tsx
+++ b/src/components/PropertyMap.tsx
@@ -24,9 +24,9 @@ const PropertyMap = ({ property }: Props) => {
             try {
                 const { street, state, city, zipcode } = property.location
                 const address = `${street && street + ","} ${city}, ${state}, ${zipcode}`
-                const apiKey = process.env.NEXT_PUBLIC_OPENCAGE_API_KEY
 
-                const response = await fetch(`https://api.opencagedata.com/geocode/v1/json?key=${apiKey}&q=${encodeURIComponent(address)}&limit=1&countrycode=CA&language=en`)
+                // // Call geocode route
+                const response = await fetch(`/api/geocode?address=${encodeURIComponent(address)}`);
 
                 if (!response.ok) {
                     throw new Error('Failed to fetch coordinates')


### PR DESCRIPTION
- Uninstall "react-map-gl": "^7.1.7", "mapbox-gl": "^3.7.0", "react-geocode": "^1.0.0-alpha.1",
- Use "leaflet": "^1.9.4", "react-leaflet": "^4.2.1", "@types/leaflet": "^1.9.12", instead
- change Map API from MapBox and Google Geocode to OpenStreetMaps and OpenCageData
- Fetch opencagedata via server